### PR TITLE
Fix nil root handling in dialogs

### DIFF
--- a/src/create_job.go
+++ b/src/create_job.go
@@ -887,7 +887,11 @@ func showError(app *tview.Application, root tview.Primitive, message string) {
 		SetText(message).
 		AddButtons([]string{"OK"}).
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-			app.SetRoot(root, true)
+			if root != nil {
+				app.SetRoot(root, true)
+			} else {
+				app.Stop()
+			}
 		})
 	app.SetRoot(modal, true)
 }
@@ -898,7 +902,11 @@ func showMessage(app *tview.Application, root tview.Primitive, message string) {
 		SetText(message).
 		AddButtons([]string{"OK"}).
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-			app.SetRoot(root, true)
+			if root != nil {
+				app.SetRoot(root, true)
+			} else {
+				app.Stop()
+			}
 		})
 	app.SetRoot(modal, true)
 }


### PR DESCRIPTION
## Summary
- avoid nil root in showError/showMessage

## Testing
- `gofmt -w src/create_job.go`

------
https://chatgpt.com/codex/tasks/task_e_683f947ffb988331a124b1002c3124fd