### PR TITLE
fix: raw TTY mode + proper shell setup for pod exec ('e')

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Static build (no glibc dependency) so the binary runs on any EIDF host.
-CGO_ENABLED=0 go build -ldflags="-s -w" -o kstool ./cmd/kstool
+CGO_ENABLED=0 "$GOROOT/bin/go" build -ldflags="-s -w" -o kstool ./cmd/kstool
 
 # Atomic-replace on the remote: scp to a temp name, then mv. mv just swaps
 # the directory entry, so a kstool that's currently running keeps executing

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -258,6 +258,19 @@ func (c *clientGo) DescribeJob(ctx context.Context, name string) (*JobSnapshot, 
 	return &JobSnapshot{Job: job, Pods: pl.Items, Events: events}, nil
 }
 
+// execCommand returns the shell invocation used for interactive pod exec.
+// Always sets TERM=xterm-256color (not forwarded from the local env) so that
+// readline inside the pod has full terminfo capabilities regardless of what the
+// outer terminal reports.  Runs "stty sane" to clear -echo or other bad tty
+// settings a container .bashrc may have set, and forces bash interactive mode
+// with -i so readline activates even if the tty check is ambiguous.
+func execCommand() []string {
+	return []string{
+		"env", "TERM=xterm-256color",
+		"/bin/sh", "-c", "stty sane; exec /bin/bash -i",
+	}
+}
+
 func (c *clientGo) ExecJob(ctx context.Context, name string, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
 	pod, err := c.pickPodForJob(ctx, name)
 	if err != nil {
@@ -277,7 +290,7 @@ func (c *clientGo) ExecJob(ctx context.Context, name string, stdin io.Reader, st
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: container,
-			Command:   []string{"/bin/bash"},
+			Command:   execCommand(),
 			Stdin:     stdin != nil,
 			Stdout:    true,
 			Stderr:    true,

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	appName = "KSTool"
-	version = "2.0.0"
+	version = "2.1.0"
 	author  = "Beining Yang@LFCS"
 )
 

--- a/internal/tui/jobs.go
+++ b/internal/tui/jobs.go
@@ -3,12 +3,15 @@ package tui
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+	"golang.org/x/term"
 
 	"github.com/suchun/kstool/internal/editor"
 	klog "github.com/suchun/kstool/internal/log"
@@ -342,11 +345,42 @@ func (v *jobsView) handleEnter() {
 func (v *jobsView) execTTY(name string) {
 	var execErr error
 	v.app.app.Suspend(func() {
-		fmt.Print("\033[H\033[2J")
+		// Open /dev/tty directly — tcell does the same thing.  os.Stdin (fd 0)
+		// may be a pipe in some shell environments (nohup, web terminals that
+		// redirect stdin), which would silently break raw mode and exec I/O.
+		tty, ttyErr := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+		if ttyErr != nil {
+			tty = nil
+		}
+
+		var (
+			stdinR  = io.Reader(os.Stdin)
+			stdoutW = io.Writer(os.Stdout)
+			stderrW = io.Writer(os.Stderr)
+			rawFd   = int(os.Stdin.Fd())
+		)
+		if tty != nil {
+			defer tty.Close()
+			stdinR = tty
+			stdoutW = tty
+			stderrW = tty
+			rawFd = int(tty.Fd())
+		}
+		rawOK := false
+		if oldState, err := term.MakeRaw(rawFd); err == nil {
+			rawOK = true
+			defer term.Restore(rawFd, oldState)
+		}
+		klog.Action("exec-tty-setup", name,
+			slog.Bool("devtty", ttyErr == nil),
+			slog.Bool("raw", rawOK),
+		)
+
+		_, _ = stdoutW.Write([]byte("\033[H\033[2J"))
 		ctx, cancel := context.WithCancel(v.app.ctx)
 		defer cancel()
-		execErr = v.app.client.ExecJob(ctx, name, os.Stdin, os.Stdout, os.Stderr, true)
-		fmt.Print("\033[H\033[2J")
+		execErr = v.app.client.ExecJob(ctx, name, stdinR, stdoutW, stderrW, true)
+		_, _ = stdoutW.Write([]byte("\033[H\033[2J"))
 	})
 	if execErr != nil {
 		v.app.showError(fmt.Errorf("exec %s: %w", name, execErr))


### PR DESCRIPTION
## What broke                                                                                                                                                                                      
  Pressing `e` to exec into a pod produced garbled output:
  - Paste markers (`^[[200~`) appeared as literal text                                                                                                                                               
  - Arrow keys showed as `^[[A` instead of navigating history                                                                                                                                        
                                                                                                                                                                                                     
  ## Root causes                                                                                                                                                                                     
  1. **No raw mode** — `execTTY` didn't call `term.MakeRaw`, so the local                                                                                                                            
     line discipline echoed every escape sequence back to the screen.                                                                                                                                
  2. **Wrong terminal fd** — tcell uses `/dev/tty` internally, not fd 0.                                                                                                                             
     In web-terminal environments `os.Stdin` can be a pipe; `MakeRaw` on                                                                                                                             
     it silently fails and exec I/O goes nowhere.                                                                                                                                                    
  3. **Bare `/bin/bash`** — no TERM was set so readline fell back to dumb                                                                                                                            
     mode. Any `stty -echo` in a container's `.bashrc` also persisted.                                                                                                                               
                                                                                                                                                                                                     
  ## Fixes                                                                                                                                                                                           
  - Open `/dev/tty` explicitly and call `term.MakeRaw` before the exec                                                                                                                               
    stream starts.                                                                                                                                                                                   
  - Replace the exec command with                                                                                                                                                                    
    `env TERM=xterm-256color /bin/sh -c 'stty sane; exec /bin/bash -i'`
    to guarantee full readline capabilities and a clean tty state.                                                                                                                                   
  - Fix `build.sh` to use `$GOROOT/bin/go` — the system `go` (1.25.4)                                                                                                                                
    and local `$GOROOT` tools (1.22.2) were mismatched, silently failing                                                                                                                             
    every build since the last toolchain update.                                                                                                                                                     
                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                       
  - [x] `echo $TERM` inside exec session shows `xterm-256color`                                                                                                                                      
  - [x] Arrow keys navigate shell history                                                                                                                                                            
  - [x] Paste does not show `^[[200~` markers                                                                                                                                                        
  - [x] `./build.sh` completes and prints `kstool deployed`
